### PR TITLE
[Fix] Wither Ring - Research Error fixed

### DIFF
--- a/src/main/java/com/Zoko061602/ThaumicRestoration/crafting/TR_Research.java
+++ b/src/main/java/com/Zoko061602/ThaumicRestoration/crafting/TR_Research.java
@@ -424,7 +424,7 @@ public class TR_Research {
 			  new ResearchHelper.RSB()
 			  .setText("research_stage."+ThaumicRestoration.ModID+":wither_ring.0")
 			  .setKnow(new Knowledge(THEORY, getCategory("AUROMANCY"), 2))
-			  .setConsumedItems(new ItemStack(Blocks.SKULL,1,1))
+			  .setConsumedItems(new ItemStack(Items.SKULL,1,1))
 			  .setWarp(2)
 			  .build(),
 			 new ResearchHelper.RSB()


### PR DESCRIPTION
The requirement for Wither Ring - Wither Skull - was called from as "Blocks" instead of an "Items", making the entry null and preventing legitimate research for the item(/thaum command is not blocked by this error). 